### PR TITLE
Check for empty values in collect_separable to avoid an error

### DIFF
--- a/src/export2mpb.jl
+++ b/src/export2mpb.jl
@@ -175,7 +175,7 @@ function prepare_mpbcalc!(
 
     # write `kvs` (if they are not nothing; we may not always want to give `kvs` explicitly,
     #              e.g. for berry phase calculations)
-    write(io, "kvs", "=")
+    write(io, "kvecs", "=")
     if kvs !== nothing 
         if kvs isa AbstractString
             write(io, "\"", kvs, "\"")

--- a/src/export2mpb.jl
+++ b/src/export2mpb.jl
@@ -174,7 +174,8 @@ function prepare_mpbcalc!(
     end
 
     # write `kvs` (if they are not nothing; we may not always want to give `kvs` explicitly,
-    #              e.g. for berry phase calculations)
+    #              e.g. for berry phase calculations); note that we write them as "kvecs"
+    #              rather than "kvs" for backwards compatibility with our .ctl files
     write(io, "kvecs", "=")
     if kvs !== nothing 
         if kvs isa AbstractString

--- a/src/read_utils.jl
+++ b/src/read_utils.jl
@@ -349,12 +349,10 @@ function collect_separable(bandirsd::Dict{String, Vector{Pair{UnitRange{Int}, Ve
 
     # Check for empty values in bandirsd and return gracefully. Otherwise the mapreduce
     # line will throw an error.
-    for (_, v) in bandirsd
-        if isempty(v)
-            warn("bandirsd has empty values. May indicate an empty lattice.")
-            return nothing
-        end
-    end
+   if any(isempty, values(bandirsd))
+      # return empty `collectibles_bands, collectibles_symvecs`
+      return Vector{UnitRange{Int}}(), Vector{Dict{String, Vector{Int}}}()
+   end
 
     Nbands = mapreduce(last∘first∘last, min, values(bandirsd)) # smallest "last" band-index
     include = Dict(klab => Int[] for klab in keys(bandirsd))

--- a/src/read_utils.jl
+++ b/src/read_utils.jl
@@ -347,6 +347,15 @@ function collect_separable(bandirsd::Dict{String, Vector{Pair{UnitRange{Int}, Ve
                 lgirsd::Dict{String, Vector{LGIrrep{D}}};
                 latestarts::Dict{String, Int}=Dict("Γ" => D)) where D
 
+    # Check for empty values in bandirsd and return gracefully. Otherwise the mapreduce
+    # line will throw an error.
+    for (_, v) in bandirsd
+        if isempty(v)
+            warn("bandirsd has empty values. May indicate an empty lattice.")
+            return nothing
+        end
+    end
+
     Nbands = mapreduce(last∘first∘last, min, values(bandirsd)) # smallest "last" band-index
     include = Dict(klab => Int[] for klab in keys(bandirsd))
     collectibles_bands   = Vector{UnitRange{Int}}()


### PR DESCRIPTION
Passing `bandirsd` that has been extracted from an empty lattice may throw a cryptic error in `collect_separable.`